### PR TITLE
Lower modulation calc rates to kr, update modulation UGen.

### DIFF
--- a/AmbiVerbGUI.sc
+++ b/AmbiVerbGUI.sc
@@ -48,7 +48,7 @@ AmbiVerbGUI {
 			preset  = AVPreset.new;
 			curPreset = "default";
 			params = preset.read(curPreset);
-			params.postln;
+			// params.postln;
 			bufNames = [];
 			buffers  = Dictionary.new;
 			curOutput = "Stereo";
@@ -61,8 +61,8 @@ AmbiVerbGUI {
 
 	// Updates AmbiverbSC parameters
 	setSynth {
-		"setting synth".postln;
-		params.postln;
+		// "setting synth".postln;
+		// params.postln;
 		(soundPlay.isPlaying).if({
 		soundPlay.set(
 				\amp, amp,
@@ -139,7 +139,7 @@ AmbiVerbGUI {
 				.font_(guiFont)
 			);
 			buttons[\play].action_({arg button;
-				button.value.postln;
+				// button.value.postln;
 				if (button.value == 1,
 					{this.start},
 					{this.stop}
@@ -154,7 +154,7 @@ AmbiVerbGUI {
 
 			bufPath.do({arg path;
 				var thisPath = path.fileName.split(separator: $.);
-				thisPath[1].postln;
+				// thisPath[1].postln;
 				if ((thisPath[1] == "wav") && (thisPath.size ==  2) ,
 					{
 						bufNames = bufNames.add(thisPath[0]);
@@ -162,7 +162,7 @@ AmbiVerbGUI {
 					}
 				)
 			});
-			buffers.postln;
+			// buffers.postln;
 			buffer = buffers[bufNames[0].asSymbol];
 
 			popUp = PopUpMenu(gui, Rect.new(255, 80, 125, 30)).items_(bufNames)
@@ -172,9 +172,9 @@ AmbiVerbGUI {
 
 			popUp.action_({arg obj;
 				buttons[\play].valueAction_(0);
-				obj.item.postln;
+				// obj.item.postln;
 				buffer = buffers[obj.item.asSymbol];
-				buffer.postln;
+				// buffer.postln;
 				this.initSynths;
 			});
 		};
@@ -189,10 +189,10 @@ AmbiVerbGUI {
 				.background_(Color.black);
 			);
 			buttons[\output].action_({arg button;
-				button.value.postln;
+				// button.value.postln;
 				buttons[\play].valueAction_(0);
 				curOutput = button.item;
-				curOutput.postln;
+				// curOutput.postln;
 				this.initSynths;
 			});
 		};
@@ -215,7 +215,7 @@ AmbiVerbGUI {
 			// Creates parameter knobs and links them to AmbiverbSC
 			data.do({arg thisData, i;
 				var knob, knobVal, thisText;
-				params[thisData[3]].postln;
+				// params[thisData[3]].postln;
 				knob = Knob(outView, 30@25).mode_(\vert).color_([Color.black, Color.green, Color.green, Color.green])
 				.action_({arg thisKnob;
 					if(((thisData[3] != \orient) && (thisData[3] != \size)),
@@ -232,8 +232,8 @@ AmbiVerbGUI {
 								{params.put(thisData[3], knobVal)}
 							);
 							this.setSynth;
-							thisData[0].postln;
-							thisData[1].postln;
+							// thisData[0].postln;
+							// thisData[1].postln;
 						},
 					);
 				}).valueAction_(
@@ -427,7 +427,7 @@ PopUpMenu(gui, Rect.new(842, 170, 35, 28)).font_(guiFont.pixelSize_(15))
 		SynthDef.new(\Stereo,
 			{arg amp = 1, buffer, mix = 0.7, preDelay = 0, crossoverFreq = 3000, lowRT = 8, highRT = 3, dispersion = 1, modWidth = 0.2, modRate =  0.2, coupRate= 0.2, coupAmt = 2pi, phaseRotRate = 0.23, phaseRotAmt = 2pi, phaseRotMix = 1, spread = 1, out;
 				var sig;
-				orient.postln;
+				// orient.postln;
 				sig = PlayBuf.ar(4, buffer, BufRateScale.kr(buffer), loop: 1);
 				sig = AmbiVerbSC.ar(sig, mix.lag(0.5), preDelay.lag(0.5), crossoverFreq.lag(0.5), lowRT.lag(0.5), highRT.lag(0.5), dispersion.lag(0.5), size, modWidth.lag(0.5), modRate.lag(0.5), coupRate.lag(0.5), coupAmt.lag(0.5), phaseRotRate.lag(0.5), phaseRotAmt.lag(0.5), orient, 10,spread.lag(0.5));
 				sig = sig * amp.lag(0.5);
@@ -438,7 +438,7 @@ PopUpMenu(gui, Rect.new(842, 170, 35, 28)).font_(guiFont.pixelSize_(15))
 		SynthDef.new(\BFormat,
 			{arg amp = 1, buffer, mix = 0.7, preDelay = 0, crossoverFreq = 3000, lowRT = 8, highRT = 3, dispersion = 1, modWidth = 0.2, modRate =  0.2, coupRate= 0.2, coupAmt = 2pi, phaseRotRate = 0.23, phaseRotAmt = 2pi, phaseRotMix = 1, spread = 1, out;
 				var sig;
-				orient.postln;
+				// orient.postln;
 				sig = PlayBuf.ar(4, buffer, BufRateScale.kr(buffer), loop: 1);
 				sig = AmbiVerbSC.ar(sig, mix.lag(0.5), preDelay.lag(0.5), crossoverFreq.lag(0.5), lowRT.lag(0.5), highRT.lag(0.5), dispersion.lag(0.5), size, modWidth.lag(0.5), modRate.lag(0.5), coupRate.lag(0.5), coupAmt.lag(0.5), phaseRotRate.lag(0.5), phaseRotAmt.lag(0.5), orient, 10,spread.lag(0.5));
 				sig = sig * amp.lag(0.5);
@@ -450,7 +450,7 @@ PopUpMenu(gui, Rect.new(842, 170, 35, 28)).font_(guiFont.pixelSize_(15))
 
 	// Starts audio
 	start {
-		params.postln;
+		// params.postln;
 		soundPlay = Synth(curOutput.asSymbol,
 			[
 				\buffer, buffer, \amp, amp,
@@ -473,9 +473,9 @@ PopUpMenu(gui, Rect.new(842, 170, 35, 28)).font_(guiFont.pixelSize_(15))
 
 	// Stops audio
 	stop {
-		soundPlay.postln;
+		// soundPlay.postln;
 		(soundPlay.isPlaying).if({
-			"Stop".postln;
+			// "Stop".postln;
 			soundPlay.free;
 		});
 	}

--- a/AmbiVerbSC.sc
+++ b/AmbiVerbSC.sc
@@ -157,7 +157,7 @@ AmbiVerbSC {
 		wet = FoaRTT.ar(wet, coupMod[0], coupMod[1], coupMod[2]);
 
 		// Applies hilbert phase rotation
-		newLFMod = LFDNoise3.kr(phaseRotRates) * phaseRotAmt;
+		newLFMod = K2A.ar(LFDNoise3.kr(phaseRotRates) * phaseRotAmt);
 		hilbert = wet;
 		hilbert.collectInPlace({arg item, i;
 			item = (Hilbert.ar(item) * [newLFMod[i].cos, newLFMod[i].sin]).sum;

--- a/AmbiVerbSC.sc
+++ b/AmbiVerbSC.sc
@@ -120,7 +120,7 @@ AmbiVerbSC {
 		allPassData1.do({arg thisData;
 			var width = (thisData[0] * modWidth.linlin(0, 1, widthRange[0], widthRange[1])) * 0.5;
 			var maxDelay = thisData[0] * 2;
-			var delay = thisData[0] + (LFDNoise3.ar(modRate) * width);
+			var delay = thisData[0] + (LFDNoise3.kr(modRate) * width);
 			sum = AllpassL.ar(sum, maxDelay, delay,  thisData[1])
 		});
 /*
@@ -130,7 +130,7 @@ AmbiVerbSC {
 			allPassChunk[0].do({arg thisData;
 				var width = thisData[0] * modWidth.linlin(0, 1, widthRange[0], widthRange[1]) * 0.5;
 				var maxDelay = thisData[0] * 2;
-				var delay = thisData[0] + (LFDNoise3.ar(modRate)* width);
+				var delay = thisData[0] + (LFDNoise3.kr(modRate)* width);
 				sum = AllpassL.ar(sum, maxDelay, delay, thisData[1]);
 			});
 			chunkSum = sum;
@@ -153,11 +153,11 @@ AmbiVerbSC {
 		wet = FoaEncode.ar(wet, FoaEncoderMatrix.newAtoB);
 
 		// Applies coupling in B-format with RTT
-		coupMod = LFDNoise3.ar(coupRates) * coupAmt;
+		coupMod = LFDNoise3.kr(coupRates) * coupAmt;
 		wet = FoaRTT.ar(wet, coupMod[0], coupMod[1], coupMod[2]);
 
 		// Applies hilbert phase rotation
-		newLFMod = LFNoise2.ar(phaseRotRates) * phaseRotAmt;
+		newLFMod = LFDNoise3.kr(phaseRotRates) * phaseRotAmt;
 		hilbert = wet;
 		hilbert.collectInPlace({arg item, i;
 			item = (Hilbert.ar(item) * [newLFMod[i].cos, newLFMod[i].sin]).sum;
@@ -179,7 +179,7 @@ AmbiVerbSC {
 		allPassData2.do({arg thisData;
 			var width = (thisData[0] * modWidth.linlin(0, 1, widthRange[0], widthRange[1])) * 0.5;
 			var maxDelay = thisData[0] * 2;
-			var delay = thisData[0] + (LFDNoise3.ar(modRate) * width);
+			var delay = thisData[0] + (LFDNoise3.kr(modRate) * width);
 			sum = AllpassL.ar(sum, maxDelay, delay, thisData[1])
 		});
 

--- a/AmbiVerbSC.sc
+++ b/AmbiVerbSC.sc
@@ -157,7 +157,7 @@ AmbiVerbSC {
 		wet = FoaRTT.ar(wet, coupMod[0], coupMod[1], coupMod[2]);
 
 		// Applies hilbert phase rotation
-		newLFMod = K2A.ar(LFDNoise3.kr(phaseRotRates) * phaseRotAmt);
+		newLFMod = LFDNoise3.ar(phaseRotRates) * phaseRotAmt;
 		hilbert = wet;
 		hilbert.collectInPlace({arg item, i;
 			item = (Hilbert.ar(item) * [newLFMod[i].cos, newLFMod[i].sin]).sum;

--- a/HelpSource/Classes/AmbiVerbSC.schelp
+++ b/HelpSource/Classes/AmbiVerbSC.schelp
@@ -67,11 +67,11 @@ WARNING::
 Size is a hardcoded parameter. It cannnot be modulated.
 ::
 
-argument:: timeModWidth
+argument:: modWidth
 
 Scales maximum amount allpass reverberator delay times modulated (1 = maximum modulation, 0 = no modulation).
 
-argument:: timeModRate
+argument:: modRate
 
 Rate at which allpass reverberators modulated (in hz).
 
@@ -125,7 +125,7 @@ AmbiVerbGUI(s);
 ::
 
 code::
-// Example for rendering AmbiVerSC with presets using CTK  
+// Example for rendering AmbiVerSC with presets using CTK
 (
 var score, synths, buffer, path, paramDict, preset, sampleRate, sampleFormat, headerFormat;
 score = CtkScore.new;

--- a/HelpSource/Tutorials/AmbiVerbTutorial.schelp
+++ b/HelpSource/Tutorials/AmbiVerbTutorial.schelp
@@ -41,7 +41,7 @@ This equation is used recursively to compute a large number of modal frequency e
 
 We can now plug these values into our reverberator formula to get the parameters needed for link::Classes/AllpassL ::.
 
-The final piece of the allpass puzzle is delay-line modulation. This simulates the imperfections of a room and blurs resonances making the tank sound more realistic. Modulation is acheived using individual link::Classes/LFDNoise3:: ugens for each allpass. The amount of modulation is controlled using a width argument with width corrisponding to a scaler of the smallest delay time in the cascade. The rate is universal for each allpass.
+The final piece of the allpass puzzle is delay-line modulation. This simulates the imperfections of a room and blurs resonances making the tank sound more realistic. Modulation is acheived using individual link::Classes/LFDNoise3:: ugens for each allpass. The amount of modulation is controlled using a width argument with width corresponding to a scaler of the smallest delay time in the cascade. The rate is universal for each allpass.
 
 subsection:: Feedback Loop
 
@@ -70,7 +70,7 @@ note::The majority of spatial manipulation of the signal is done using the Ambis
 
 subsection:: Going From B to A
 
-The signal is initially Decoded to A-format which outputs 4 signals corrisponding to the vertices a tetrahedran in space. One of the best ways to make something sound spatial is to transform each of these signals in a similar yet different fashion. In AmbiVerbSC, this is accomplished by calculating 4 different arrays of delay times based off of rooms with nearly identical dimensions. This corrisponds to 4 related monophonic reverberators which our A-format signal is sent through. With delay-time modulation, this creates a strong foundation for a rich spatial image.
+The signal is initially Decoded to A-format which outputs 4 signals corresponding to the vertices a tetrahedran in space. One of the best ways to make something sound spatial is to transform each of these signals in a similar yet different fashion. In AmbiVerbSC, this is accomplished by calculating 4 different arrays of delay times based off of rooms with nearly identical dimensions. This corrisponds to 4 related monophonic reverberators which our A-format signal is sent through. With delay-time modulation, this creates a strong foundation for a rich spatial image.
 
 SuperCollider makes this process easy with multichannel expansion. As long as the delay time arrays are manipulated properly, the A-format signal can be sent through the same code used for the monophonic reverb with no hiccups.
 
@@ -84,7 +84,7 @@ Once our A-format signal has been reverberated, delayed, and scaled, it is conve
 
 subsection:: Coupling
 
-Still in B-format, the signal is then coupled. Coupling mixes the signals in space using a matrix. This allows for varying degrees of the A-Format signal to pass through all of the reverberators rather than being fixed at a tetrahedral point. This mixing is implemented using the ATK's link::Classes/FoaRTT:: which is modulated with a series of link::Classes/LFNoise2::. This transformed signal is then converted back to A-format and sent again through the loop.
+Still in B-format, the signal is then coupled. Coupling mixes the signals in space using a matrix. This allows for varying degrees of the A-Format signal to pass through all of the reverberators rather than being fixed at a tetrahedral point. This mixing is implemented using the ATK's link::Classes/FoaRTT:: which is modulated with a series of link::Classes/LFDNoise3::. This transformed signal is then converted back to A-format and sent again through the loop.
 
 section:: AmbiVerbGUI
 


### PR DESCRIPTION
Considering Nyquist frequency of the default control rate is about 345Hz (fs 44100, 64 sample block size), running the modulation ugens at control rate seems reasonable (these control delay times, b-format rotation, as well as phase rotation). With a quick test, swapping these UGens for `kr` update rates cuts the _peak_ CPU of the reverb in half, even maintaining cubic interpolation.

`LFNoise2` was replaced with `LFDNoise3`, which recovers more quickly from very low modulation rates (common in the kind of spatial modulation used here). `LFNoise2` is also known to overshoot its range, whereas `LFDNoise3` won't.

~~In the case of the Hilbert phase rotation, the `kr` modulator is converted back to `ar` via `K2A`~~(update: reverted—maybe best to leave this UGen `ar`), since this modulator multiplies the signal directly, whereas the others are modulating UGen parameters—confirmed that DelayL [interpolates kr>ar control signals internally](https://github.com/supercollider/supercollider/blob/f806ace7bd8565dd174e7d47a1b32aaa4175a46e/server/plugins/DelayUGens.cpp#L3774-L3776), as do the [FoaRotate](https://github.com/supercollider/sc3-plugins/blob/4ef414c730781ba632c56b4c5eaa2049de050255/source/ATK/AtkUGens.cpp#L497) UGens.

It's worth doing a listening test to confirm these changes don't impact the sound (I don't currently have a detailed listening setup), or in any case review the changes closely in case I've overlooked some aspect of how these modulators are used.

Docs updated to reflect the change.